### PR TITLE
Enable KMS encryption and capability of using customer-managed key

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
     name: Minimum version check
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:0.12.0
+      image: hashicorp/terraform:0.12.31
     steps:
       - uses: actions/checkout@master
       - name: Validate Code

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following resources will be created:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.31 |
 
 ## Providers
 

--- a/_data.tf
+++ b/_data.tf
@@ -1,1 +1,3 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/_variables.tf
+++ b/_variables.tf
@@ -6,3 +6,9 @@ variable "trust_accounts" {
   type        = list(string)
   description = "Accounts to trust and allow ECR fetch"
 }
+
+variable "ecr_cmk_encryption" {
+  type        = bool
+  description = "Enabled KMS CMK encryption for ECR repository"
+  default     = false
+}

--- a/ecr-policies.tf
+++ b/ecr-policies.tf
@@ -41,4 +41,6 @@ resource "aws_ecr_repository_policy" "default" {
   ]
 }
 EOF
+
+  depends_on = [aws_ecr_repository.default]
 }

--- a/ecr-repositories.tf
+++ b/ecr-repositories.tf
@@ -4,4 +4,11 @@ resource "aws_ecr_repository" "default" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = try(aws_kms_key.ecr[0].arn, false) ? aws_kms_key.ecr[0].arn : null
+  }
+
+  depends_on = [aws_kms_alias.ecr]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,57 @@
+data "aws_iam_policy_document" "kms_policy_ecr" {
+  count = var.ecr_cmk_encryption ? 1 : 0
+  statement {
+    sid    = "Allow direct access to key metadata to the account"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "kms:*"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "kms:CreateGrant",
+      "kms:RetireGrant"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = [join(",", var.trust_accounts)]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ecr.${data.aws_region.current.name}.amazonaws.com"]
+    }
+    sid = "Allow access through Amazon ECR for all principals in the account that are authorized to use Amazon ECR"
+  }
+}
+
+
+resource "aws_kms_key" "ecr" {
+  count                   = var.ecr_cmk_encryption ? 1 : 0
+  deletion_window_in_days = 30
+  description             = "Customer-managed key that protects ECR data"
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms_policy_ecr[0].json
+}
+
+resource "aws_kms_alias" "ecr" {
+  count         = var.ecr_cmk_encryption ? 1 : 0
+  name          = "alias/cmk/ecr"
+  target_key_id = aws_kms_key.ecr[0].key_id
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.31"
 }


### PR DESCRIPTION
Enable KMS encryption and capability of using customer-managed key

By default, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts your data at rest using an AES-256 encryption algorithm. For more control over the encryption for your Amazon ECR repositories, you can use server-side encryption with KMS keys stored in AWS Key Management Service (AWS KMS). When you use AWS KMS to encrypt your data, you can either use the default AWS managed key, which is managed by Amazon ECR, or specify your own KMS key.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.