### PR TITLE
Removing deprecated ScanOnPush configuration

### DIFF
--- a/ecr-repositories.tf
+++ b/ecr-repositories.tf
@@ -1,10 +1,6 @@
 resource "aws_ecr_repository" "default" {
   name = var.name
 
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-
   encryption_configuration {
     encryption_type = "KMS"
     kms_key         = length(var.kms_key_arn) > 0 ? var.kms_key_arn : ""


### PR DESCRIPTION
ScanOnPush configuration at the repository level is deprecated in favor of registry level scan filters.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
